### PR TITLE
Undefine Block Interface

### DIFF
--- a/Block/Checkout/Payment.php
+++ b/Block/Checkout/Payment.php
@@ -21,7 +21,7 @@
 
 namespace Paybox\Epayment\Block\Checkout;
 
-class Payment
+class Payment extends \Magento\Framework\View\Element\Template
 {
     protected function _construct()
     {


### PR DESCRIPTION
I have installed POS, RMA plugins after that I get an error something like this "Undefine Block Interface Paybox"  when i use this plugin it gives me this errors
and when i edit the file and add this 
"class Payment extends \Magento\Framework\View\Element\Template" 
it works fine.
Let know if i'm right ?

I think this is the solution let know if you investigate about that?